### PR TITLE
Correct habit's lists' updates

### DIFF
--- a/Active/Active/Controllers/Base.lproj/Main.storyboard
+++ b/Active/Active/Controllers/Base.lproj/Main.storyboard
@@ -252,12 +252,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="1000"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <view key="tableFooterView" contentMode="scaleToFill" id="U4g-rN-Yvd" userLabel="Footer">
+                        <view key="tableFooterView" contentMode="scaleToFill" misplaced="YES" id="U4g-rN-Yvd" userLabel="Footer">
                             <rect key="frame" x="0.0" y="883" width="375" height="104"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D90-7S-rS4" customClass="RoundedButton" customModule="Active" customModuleProvider="target">
-                                    <rect key="frame" x="117.5" y="27" width="140" height="50"/>
+                                    <rect key="frame" x="117.5" y="193.5" width="140" height="50"/>
                                     <color key="backgroundColor" red="0.18431372549019609" green="0.21176470588235294" blue="0.25098039215686274" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="EpX-yy-wTD"/>
@@ -1404,8 +1404,8 @@ you think of adding a new one?</string>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="y7q-nn-pWX"/>
-        <segue reference="J1H-vQ-s49"/>
-        <segue reference="Xkx-Wi-bYR"/>
+        <segue reference="G29-rb-isc"/>
+        <segue reference="43l-ZQ-AR3"/>
+        <segue reference="5mV-Cj-rFr"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Active/Active/Controllers/HabitsTableViewController.swift
+++ b/Active/Active/Controllers/HabitsTableViewController.swift
@@ -283,6 +283,11 @@ extension HabitsTableViewController {
         for type: NSFetchedResultsChangeType,
         newIndexPath: IndexPath?
     ) {
+        // Only execute the updates if the segment being shown is handled by the passed controller.
+        // There're two fetchedResultsController instances managing different segments of the table view,
+        // One for the in progress habits and another for the completed ones. Only update the one being displayed.
+        guard shouldUpdateSegmentFrom(controller: controller) else { return }
+
         // Add or remove rows based on the kind of changes:
         switch type {
         case .delete:
@@ -302,6 +307,19 @@ extension HabitsTableViewController {
             if let indexPath = indexPath {
                 tableView.reloadRows(at: [indexPath], with: .automatic)
             }
+        }
+    }
+
+    /// Informs if the changed fetched results controller should update the current segment being displayed
+    /// by the table view.
+    /// - Parameter fetchedResultsController: The updated fetched results controller.
+    /// - Returns: True if the update should be displayed by the segment, false otherwise.
+    private func shouldUpdateSegmentFrom(controller: NSFetchedResultsController<NSFetchRequestResult>) -> Bool {
+        switch selectedSegment {
+        case .inProgress:
+            return controller == progressfetchedResultsController
+        case .completed:
+            return controller == completedfetchedResultsController
         }
     }
 


### PR DESCRIPTION
After adding a new challenge to a completed habit, the fetched results controller was updated, but the segment being displayed wasn't handled by it, so it was causing crashes in the table view updates, which were inconsistent.