### PR TITLE
Unschedule the user notifications.

### DIFF
--- a/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController+PromptSection.swift
+++ b/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController+PromptSection.swift
@@ -15,7 +15,7 @@ extension HabitDetailsViewController {
 
     /// Sets the current as executed or not, depending on the user's action.
     @IBAction func informActivityExecution(_ sender: UISwitch) {
-        guard let challenge = habit.getCurrentChallenge(), let day = challenge.getCurrentDay() else {
+        guard let challenge = habit.getCurrentChallenge() else {
             assertionFailure(
                 "Inconsistency: There isn't a current habit day but the prompt is being displayed."
             )
@@ -25,11 +25,11 @@ extension HabitDetailsViewController {
         // Get the user's answer.
         let wasExecuted = sender.isOn
 
-        day.managedObjectContext?.perform {
-            day.wasExecuted = wasExecuted
+        challenge.managedObjectContext?.perform {
+            challenge.markCurrentDayAsExecuted(wasExecuted)
 
             // TODO: Display an error to the user.
-            try? day.managedObjectContext?.save()
+            try? challenge.managedObjectContext?.save()
 
             DispatchQueue.main.async {
                 // Update the prompt view.

--- a/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController+PromptSection.swift
+++ b/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController+PromptSection.swift
@@ -28,6 +28,19 @@ extension HabitDetailsViewController {
         challenge.managedObjectContext?.perform {
             challenge.markCurrentDayAsExecuted(wasExecuted)
 
+            // Schedule / unschedule the notifications for the day, depending on the user's answer.
+            let dayNotifications = self.notificationStorage.notifications(
+                from: challenge.managedObjectContext!,
+                habit: self.habit,
+                andDay: Date()
+            ).filter { $0.fireDate?.isFuture ?? false}
+
+            if wasExecuted {
+                self.notificationScheduler.unschedule(dayNotifications)
+            } else {
+                self.notificationScheduler.schedule(dayNotifications)
+            }
+
             // TODO: Display an error to the user.
             try? challenge.managedObjectContext?.save()
 

--- a/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController.swift
+++ b/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController.swift
@@ -92,6 +92,12 @@ class HabitDetailsViewController: UIViewController {
         }
     }
 
+    /// The notificationStorage used to get the notifications for the current day.
+    var notificationStorage: NotificationStorage!
+
+    /// The notificationScheduler used to unschedule the current day's notifications, in case it's marked as executed.
+    var notificationScheduler: NotificationScheduler!
+
     /// The view holding the prompt for the current day.
     /// - Note: This view is only displayed if today is a challenge day to be accounted.
     @IBOutlet weak var promptContentView: UIView!
@@ -312,6 +318,14 @@ class HabitDetailsViewController: UIViewController {
         assert(
             notificationManager != nil,
             "Error: the notification manager wasn't injected."
+        )
+        assert(
+            notificationStorage != nil,
+            "Error: the notification storage wasn't injected."
+        )
+        assert(
+            notificationScheduler != nil,
+            "Error: the notification scheduler wasn't injected."
         )
     }
 

--- a/Active/Active/Controllers/HabitsTableViewController.swift
+++ b/Active/Active/Controllers/HabitsTableViewController.swift
@@ -158,6 +158,10 @@ class HabitsTableViewController: UITableViewController, NSFetchedResultsControll
                 habitDetailsController.container = container
                 habitDetailsController.habitStorage = habitStorage
                 habitDetailsController.notificationManager = notificationManager
+                habitDetailsController.notificationStorage = NotificationStorage()
+                habitDetailsController.notificationScheduler = NotificationScheduler(
+                    notificationManager: notificationManager
+                )
 
                 // Get the selected habit for injection.
                 guard let indexPath = tableView.indexPathForSelectedRow else {

--- a/Active/Active/Storage/HabitStorage.swift
+++ b/Active/Active/Storage/HabitStorage.swift
@@ -280,14 +280,13 @@ class HabitStorage {
         }
     }
 
-    /// Edits the habit's fire times by removing the old entities and adding the new ones.
-    /// - Parameters:
-    ///     - fireTimes: The fire times to be added.
-    ///     - habit: The habit to be edited.
-
     /// Removes the passed habit from the database.
     /// - Parameter context: The context used to delete the habit from.
     func delete(_ habit: HabitMO, from context: NSManagedObjectContext) {
+        if let notifications = habit.notifications as? Set<NotificationMO> {
+            notificationScheduler.unschedule([NotificationMO](notifications))
+        }
+
         context.delete(habit)
     }
 

--- a/Active/Active/Storage/NotificationStorage.swift
+++ b/Active/Active/Storage/NotificationStorage.swift
@@ -136,6 +136,30 @@ class NotificationStorage {
         return results?.first
     }
 
+    /// Fetches the stored notifications within the specific day's date.
+    /// - Parameters:
+    ///     - context: The context used to fetch the entities from.
+    ///     - habit: one of the habits associated with the notification entity to be searched.
+    ///     - day: the day's date to look for notifications.
+    /// - Returns: the notifications within the passed day.
+    func notifications(
+        from context: NSManagedObjectContext,
+        habit: HabitMO,
+        andDay dayDate: Date
+    ) -> [NotificationMO] {
+        // Declare the day's filter predicate. The fire dates must be in between the day's begin and end.
+        let dayPredicate = NSPredicate(
+            format: "%@ <= fireDate AND fireDate <= %@",
+            dayDate.getBeginningOfDay() as NSDate,
+            dayDate.getEndOfDay() as NSDate
+        )
+        if let notificationsSet = habit.notifications?.filtered(using: dayPredicate) as? Set<NotificationMO> {
+            return [NotificationMO](notificationsSet)
+        } else {
+            return []
+        }
+    }
+
     /// Deletes from storage the passed notification.
     /// - Parameters:
     ///     - context: The context used to delete the notification from.

--- a/Active/ActiveTests/Integration Tests/Storage Tests/NotificationStorageTests.swift
+++ b/Active/ActiveTests/Integration Tests/Storage Tests/NotificationStorageTests.swift
@@ -98,6 +98,42 @@ class NotificationStorageTests: IntegrationTestCase {
         )
     }
 
+    func testFetchingNotificationsByDate() {
+        // 1. Declare some dummy notifications.
+        let dummyHabit = habitFactory.makeDummy()
+        if let notificationsSet = dummyHabit.notifications as? Set<NotificationMO> {
+            dummyHabit.removeFromNotifications(notificationsSet as NSSet)
+        }
+
+        let notifications = [
+            notificationFactory.makeDummy(),
+            notificationFactory.makeDummy(),
+            notificationFactory.makeDummy()
+        ]
+        let fireDates = (0..<3).compactMap { Date().getBeginningOfDay().byAddingMinutes($0) }
+
+        for notification in notifications {
+            let index = notifications.index(of: notification)!
+            let fireDate = fireDates[index]
+
+            notification.habit = dummyHabit
+            notification.fireDate = fireDate
+        }
+
+        // 2. Fetch them by using today's date.
+        let fetchedNotifications = notificationStorage.notifications(
+            from: context,
+            habit: dummyHabit,
+            andDay: Date()
+        )
+
+        // 3. Assert the notifications were correclty returned.
+        XCTAssertEqual(notifications.count, fetchedNotifications.count)
+        for notification in fetchedNotifications {
+            XCTAssertNotNil(notifications.index(of: notification))
+        }
+    }
+
     func testNotificationCreationTwiceShouldThrow() {
         // 1. Declare a dummy habit with dummy notifications already created.
         // 1.1 Get its day and fire time.


### PR DESCRIPTION
The user notifications are unscheduled in two cases:
- The current day is marked as executed and there're user notifications to be delivered.
- The habit is deleted.

Closes #58.