### PR TITLE
Fix fire times creation from habit details controller.

### DIFF
--- a/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController+FireTimesSection.swift
+++ b/Active/Active/Controllers/HabitDetailsViewController/HabitDetailsViewController+FireTimesSection.swift
@@ -67,6 +67,8 @@ extension HabitDetailsViewController: FireTimesSelectionViewControllerDelegate {
 
     func didSelectFireTimes(_ fireTimes: [FireTimesDisplayable.FireTime]) {
         _ = habitStorage.edit(habit, using: container.viewContext, and: fireTimes)
+        // Save it to make any new changes in sync.
+        try? container.viewContext.save()
     }
 }
 


### PR DESCRIPTION
The changes were not being saved, and any new edition in the habit was getting out of sync.
Closes #69.